### PR TITLE
feat: add k6 sensor feed, test-stack & frontend API

### DIFF
--- a/orchestration/apphost-compose/scripts/k6-sensor-feed.js
+++ b/orchestration/apphost-compose/scripts/k6-sensor-feed.js
@@ -1,0 +1,348 @@
+/**
+ * TC Agro Solutions - k6 Sensor Feed Script
+ * ===========================================
+ * Simulates IoT sensors continuously sending readings to the Sensor Ingest API.
+ *
+ * Prerequisites:
+ *   - Services running (docker compose up)
+ *   - At least one sensor created via Farm Service (test-stack.sh --seed)
+ *
+ * Usage:
+ *   # Default: 5 VUs, 2 minutes, 1 reading/sec per VU
+ *   k6 run scripts/k6-sensor-feed.js
+ *
+ *   # Custom duration and VUs
+ *   k6 run --vus 10 --duration 5m scripts/k6-sensor-feed.js
+ *
+ *   # Override service URLs
+ *   k6 run -e SENSOR_URL=http://localhost:5003 \
+ *          -e IDENTITY_URL=http://localhost:5001 \
+ *          scripts/k6-sensor-feed.js
+ *
+ *   # Use batch endpoint (sends 10 readings per request)
+ *   k6 run -e MODE=batch scripts/k6-sensor-feed.js
+ *
+ *   # Custom credentials
+ *   k6 run -e EMAIL=admin@test.com -e PASSWORD=Admin@123 scripts/k6-sensor-feed.js
+ *
+ *   # Higher throughput stress test
+ *   k6 run --vus 20 --duration 10m -e INTERVAL=200 scripts/k6-sensor-feed.js
+ */
+
+import http from 'k6/http';
+import { check, sleep, fail } from 'k6';
+import { Rate, Counter, Trend } from 'k6/metrics';
+
+// =============================================================================
+// CONFIGURATION
+// =============================================================================
+
+const SENSOR_URL = __ENV.SENSOR_URL || 'http://localhost:5003';
+const IDENTITY_URL = __ENV.IDENTITY_URL || 'http://localhost:5001';
+const FARM_URL = __ENV.FARM_URL || 'http://localhost:5002';
+const EMAIL = __ENV.EMAIL || 'producer@test.com';
+const PASSWORD = __ENV.PASSWORD || 'Test@123456';
+const MODE = __ENV.MODE || 'single'; // 'single' or 'batch'
+const BATCH_SIZE = parseInt(__ENV.BATCH_SIZE || '10');
+const INTERVAL_MS = parseInt(__ENV.INTERVAL || '1000'); // ms between readings
+
+// =============================================================================
+// CUSTOM METRICS
+// =============================================================================
+
+const readingsAccepted = new Counter('readings_accepted');
+const readingsRejected = new Counter('readings_rejected');
+const readingLatency = new Trend('reading_latency_ms');
+const successRate = new Rate('reading_success_rate');
+
+// =============================================================================
+// k6 OPTIONS
+// =============================================================================
+
+export const options = {
+  scenarios: {
+    sensor_feed: {
+      executor: 'constant-vus',
+      vus: parseInt(__ENV.VUS || '5'),
+      duration: __ENV.DURATION || '2m',
+    },
+  },
+  thresholds: {
+    reading_success_rate: ['rate>0.95'],       // 95% success rate
+    reading_latency_ms: ['p(95)<500'],         // p95 latency < 500ms
+    http_req_duration: ['p(99)<2000'],         // p99 < 2s
+  },
+};
+
+// =============================================================================
+// SENSOR SIMULATION HELPERS
+// =============================================================================
+
+/**
+ * Simulates realistic sensor metrics with gradual drift and noise.
+ * Each VU maintains its own sensor state across iterations.
+ */
+class SensorSimulator {
+  constructor(sensorId, plotId) {
+    this.sensorId = sensorId;
+    this.plotId = plotId;
+    // Base values with some per-sensor variation
+    this.baseTemp = 22 + Math.random() * 10;       // 22-32°C base
+    this.baseHumidity = 45 + Math.random() * 25;    // 45-70% base
+    this.baseSoilMoisture = 30 + Math.random() * 20; // 30-50% base
+    this.battery = 80 + Math.random() * 20;          // 80-100% start
+    this.tick = 0;
+  }
+
+  generateReading() {
+    this.tick++;
+
+    // Simulate diurnal temperature cycle (±5°C sine wave)
+    const hourAngle = (this.tick % 360) * (Math.PI / 180);
+    const diurnalShift = Math.sin(hourAngle) * 5;
+
+    // Add random noise
+    const tempNoise = (Math.random() - 0.5) * 2;
+    const humNoise = (Math.random() - 0.5) * 5;
+    const soilNoise = (Math.random() - 0.5) * 3;
+
+    // Gradual battery drain
+    this.battery = Math.max(5, this.battery - (0.01 + Math.random() * 0.02));
+
+    // Occasional rainfall (5% chance per reading)
+    const rainfall = Math.random() < 0.05 ? Math.random() * 15 : null;
+
+    // If it rains, soil moisture increases
+    if (rainfall) {
+      this.baseSoilMoisture = Math.min(90, this.baseSoilMoisture + rainfall * 0.5);
+    } else {
+      // Slow drying
+      this.baseSoilMoisture = Math.max(15, this.baseSoilMoisture - 0.05);
+    }
+
+    return {
+      sensorId: this.sensorId,
+      plotId: this.plotId,
+      timestamp: new Date().toISOString(),
+      temperature: clamp(this.baseTemp + diurnalShift + tempNoise, -50, 70),
+      humidity: clamp(this.baseHumidity + humNoise - diurnalShift * 0.5, 0, 100),
+      soilMoisture: clamp(this.baseSoilMoisture + soilNoise, 0, 100),
+      rainfall: rainfall,
+      batteryLevel: clamp(this.battery, 0, 100),
+    };
+  }
+}
+
+function clamp(value, min, max) {
+  return Math.round(Math.max(min, Math.min(max, value)) * 10) / 10;
+}
+
+// =============================================================================
+// SETUP - Runs once before VUs start
+// =============================================================================
+
+export function setup() {
+  console.log(`\n=== TC Agro - k6 Sensor Feed ===`);
+  console.log(`Mode: ${MODE} | Interval: ${INTERVAL_MS}ms | Batch size: ${BATCH_SIZE}`);
+  console.log(`Sensor Ingest: ${SENSOR_URL}`);
+  console.log(`Identity: ${IDENTITY_URL}\n`);
+
+  // 1. Login
+  const loginRes = http.post(
+    `${IDENTITY_URL}/auth/login`,
+    JSON.stringify({ email: EMAIL, password: PASSWORD }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+
+  const loginOk = check(loginRes, {
+    'login: status 200': (r) => r.status === 200,
+    'login: has token': (r) => {
+      try { return !!JSON.parse(r.body).jwtToken; } catch { return false; }
+    },
+  });
+
+  if (!loginOk) {
+    console.error(`Login failed (${loginRes.status}): ${loginRes.body}`);
+    console.error('Make sure services are running and user exists (run test-stack.sh --seed first)');
+    fail('Login failed');
+  }
+
+  const token = JSON.parse(loginRes.body).jwtToken;
+  console.log(`Authenticated as ${EMAIL}`);
+
+  const authHeaders = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+
+  // 2. Get sensors from Sensor Ingest
+  const sensorsRes = http.get(`${SENSOR_URL}/api/sensors?pageSize=100`, {
+    headers: authHeaders,
+  });
+
+  let sensors = [];
+  if (sensorsRes.status === 200) {
+    try {
+      const body = JSON.parse(sensorsRes.body);
+      sensors = (body.data || []).map((s) => ({
+        id: s.sensorId || s.id,
+        plotId: s.plotId,
+        plotName: s.plotName,
+      }));
+    } catch (e) {
+      console.warn(`Failed to parse sensors response: ${e}`);
+    }
+  }
+
+  if (sensors.length === 0) {
+    // Try listing from Farm service as fallback
+    console.warn('No sensors found in Sensor Ingest. Trying Farm service...');
+    const farmSensorsRes = http.get(`${FARM_URL}/api/sensors?pageSize=100`, {
+      headers: authHeaders,
+    });
+
+    if (farmSensorsRes.status === 200) {
+      try {
+        const body = JSON.parse(farmSensorsRes.body);
+        const farmSensors = body.data || body;
+        sensors = (Array.isArray(farmSensors) ? farmSensors : []).map((s) => ({
+          id: s.id,
+          plotId: s.plotId,
+          plotName: s.plotName || 'Unknown',
+        }));
+      } catch (e) {
+        console.warn(`Failed to parse farm sensors: ${e}`);
+      }
+    }
+  }
+
+  if (sensors.length === 0) {
+    console.error('\nNo sensors found! Create sensors first:');
+    console.error('  ./scripts/test-stack.sh --seed');
+    fail('No sensors available');
+  }
+
+  console.log(`\nFound ${sensors.length} sensor(s):`);
+  sensors.forEach((s) => console.log(`  - ${s.id} (plot: ${s.plotName})`));
+  console.log('');
+
+  return { token, sensors };
+}
+
+// =============================================================================
+// VU CODE - Runs for each virtual user
+// =============================================================================
+
+export default function (data) {
+  const { token, sensors } = data;
+
+  // Each VU picks a sensor based on its VU ID (round-robin)
+  const sensorIdx = (__VU - 1) % sensors.length;
+  const sensor = sensors[sensorIdx];
+
+  // Initialize simulator (persists across iterations via closure hack)
+  if (!globalThis.__simulators) {
+    globalThis.__simulators = {};
+  }
+  if (!globalThis.__simulators[__VU]) {
+    globalThis.__simulators[__VU] = new SensorSimulator(sensor.id, sensor.plotId);
+  }
+  const sim = globalThis.__simulators[__VU];
+
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+
+  if (MODE === 'batch') {
+    sendBatchReading(sim, headers);
+  } else {
+    sendSingleReading(sim, headers);
+  }
+
+  // Wait before next reading
+  sleep(INTERVAL_MS / 1000);
+}
+
+// =============================================================================
+// SEND FUNCTIONS
+// =============================================================================
+
+function sendSingleReading(sim, headers) {
+  const reading = sim.generateReading();
+
+  const res = http.post(`${SENSOR_URL}/api/readings`, JSON.stringify(reading), {
+    headers,
+    tags: { endpoint: 'POST /api/readings' },
+  });
+
+  const ok = check(res, {
+    'reading: status 200-202': (r) => r.status >= 200 && r.status < 300,
+  });
+
+  readingLatency.add(res.timings.duration);
+
+  if (ok) {
+    readingsAccepted.add(1);
+    successRate.add(1);
+  } else {
+    readingsRejected.add(1);
+    successRate.add(0);
+    if (__ITER < 3) {
+      // Log first few errors for debugging
+      console.warn(`[VU${__VU}] Reading rejected (${res.status}): ${res.body}`);
+    }
+  }
+}
+
+function sendBatchReading(sim, headers) {
+  const readings = [];
+  for (let i = 0; i < BATCH_SIZE; i++) {
+    readings.push(sim.generateReading());
+    // Small time offset per reading in batch
+    sleep(0.01);
+  }
+
+  const payload = JSON.stringify({ readings });
+
+  const res = http.post(`${SENSOR_URL}/api/readings/batch`, payload, {
+    headers,
+    tags: { endpoint: 'POST /api/readings/batch' },
+  });
+
+  const ok = check(res, {
+    'batch: status 200-202': (r) => r.status >= 200 && r.status < 300,
+  });
+
+  readingLatency.add(res.timings.duration);
+
+  if (ok) {
+    try {
+      const body = JSON.parse(res.body);
+      readingsAccepted.add(body.processedCount || BATCH_SIZE);
+      readingsRejected.add(body.failedCount || 0);
+      successRate.add(body.failedCount === 0 ? 1 : 0);
+    } catch {
+      readingsAccepted.add(BATCH_SIZE);
+      successRate.add(1);
+    }
+  } else {
+    readingsRejected.add(BATCH_SIZE);
+    successRate.add(0);
+    if (__ITER < 3) {
+      console.warn(`[VU${__VU}] Batch rejected (${res.status}): ${res.body}`);
+    }
+  }
+}
+
+// =============================================================================
+// TEARDOWN
+// =============================================================================
+
+export function teardown(data) {
+  console.log('\n=== Sensor Feed Complete ===');
+  console.log(`Sensors used: ${data.sensors.length}`);
+  console.log(`Mode: ${MODE}`);
+  console.log('Check Grafana at http://localhost:3000 for metrics.');
+  console.log('Check the frontend at http://localhost:5010 to see the data.\n');
+}

--- a/orchestration/apphost-compose/scripts/test-stack.sh
+++ b/orchestration/apphost-compose/scripts/test-stack.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TC Agro Solutions - Full Stack Test Script
+# =============================================================================
+# Builds, starts, seeds data, and opens the frontend for end-to-end testing.
+#
+# Usage:
+#   ./scripts/test-stack.sh          # Build + start + seed
+#   ./scripts/test-stack.sh --seed   # Only seed data (services already running)
+#   ./scripts/test-stack.sh --down   # Stop everything
+# =============================================================================
+
+set -euo pipefail
+
+COMPOSE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$COMPOSE_DIR"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[OK]${NC} $1"; }
+warn() { echo -e "${YELLOW}[!!]${NC} $1"; }
+err()  { echo -e "${RED}[ERR]${NC} $1"; }
+info() { echo -e "${CYAN}[>>]${NC} $1"; }
+
+# Service URLs
+IDENTITY_URL="http://localhost:5001"
+FARM_URL="http://localhost:5002"
+SENSOR_URL="http://localhost:5003"
+FRONTEND_URL="http://localhost:5010"
+
+# =============================================================================
+# FUNCTIONS
+# =============================================================================
+
+wait_for_service() {
+  local name="$1" url="$2" max_attempts="${3:-60}"
+  local attempt=0
+
+  info "Waiting for $name at $url ..."
+  while [ $attempt -lt $max_attempts ]; do
+    if curl -sf "$url/health" > /dev/null 2>&1; then
+      log "$name is healthy"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+
+  err "$name did not become healthy after $((max_attempts * 2))s"
+  return 1
+}
+
+wait_for_frontend() {
+  local max_attempts=30 attempt=0
+  info "Waiting for Frontend at $FRONTEND_URL ..."
+  while [ $attempt -lt $max_attempts ]; do
+    if curl -sf "$FRONTEND_URL/" > /dev/null 2>&1; then
+      log "Frontend is ready"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+  warn "Frontend did not respond (may still be building)"
+}
+
+build_and_start() {
+  info "Building and starting full stack..."
+  docker compose build --parallel 2>&1 | tail -5
+  docker compose up -d
+  echo ""
+
+  # Wait for infrastructure first
+  info "Waiting for infrastructure..."
+  local attempt=0
+  while [ $attempt -lt 30 ]; do
+    if docker compose exec -T postgres pg_isready -U postgres > /dev/null 2>&1; then
+      log "PostgreSQL is ready"
+      break
+    fi
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+
+  # Wait for services
+  wait_for_service "Identity Service" "$IDENTITY_URL"
+  wait_for_service "Farm Service" "$FARM_URL"
+  wait_for_service "Sensor Ingest Service" "$SENSOR_URL"
+  wait_for_frontend
+  echo ""
+}
+
+seed_data() {
+  info "=== Seeding test data ==="
+  echo ""
+
+  # ----------------------------------------------------------
+  # Step 1: Register user
+  # ----------------------------------------------------------
+  info "1/6 - Registering test user..."
+  REGISTER_RESP=$(curl -sf -X POST "$IDENTITY_URL/auth/register" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "name": "Test Producer",
+      "email": "producer@test.com",
+      "password": "Test@123456",
+      "role": "Producer"
+    }' 2>&1) || true
+
+  if echo "$REGISTER_RESP" | grep -qi "already\|exists\|conflict"; then
+    warn "User already exists (OK)"
+  else
+    log "User registered"
+  fi
+
+  # ----------------------------------------------------------
+  # Step 2: Login
+  # ----------------------------------------------------------
+  info "2/6 - Logging in..."
+  LOGIN_RESP=$(curl -sf -X POST "$IDENTITY_URL/auth/login" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "email": "producer@test.com",
+      "password": "Test@123456"
+    }')
+
+  TOKEN=$(echo "$LOGIN_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['jwtToken'])" 2>/dev/null) || {
+    err "Login failed. Response: $LOGIN_RESP"
+    err "Make sure Identity Service is running and the user was registered."
+    return 1
+  }
+  log "Got JWT token: ${TOKEN:0:20}..."
+
+  AUTH="Authorization: Bearer $TOKEN"
+
+  # ----------------------------------------------------------
+  # Step 3: Create Property
+  # ----------------------------------------------------------
+  info "3/6 - Creating property..."
+  PROP_RESP=$(curl -sf -X POST "$FARM_URL/api/properties" \
+    -H "Content-Type: application/json" \
+    -H "$AUTH" \
+    -d '{
+      "name": "Fazenda Boa Vista",
+      "address": "Estrada Rural Km 15",
+      "city": "Ribeirao Preto",
+      "state": "SP",
+      "country": "Brazil",
+      "areaHectares": 250.5,
+      "latitude": -21.1767,
+      "longitude": -47.8208
+    }')
+
+  PROPERTY_ID=$(echo "$PROP_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null) || {
+    err "Create property failed. Response: $PROP_RESP"
+    return 1
+  }
+  log "Property created: $PROPERTY_ID"
+
+  # ----------------------------------------------------------
+  # Step 4: Create Plot
+  # ----------------------------------------------------------
+  info "4/6 - Creating plot..."
+  PLOT_RESP=$(curl -sf -X POST "$FARM_URL/api/plots" \
+    -H "Content-Type: application/json" \
+    -H "$AUTH" \
+    -d "{
+      \"propertyId\": \"$PROPERTY_ID\",
+      \"name\": \"Talhao Norte\",
+      \"cropType\": \"Soja\",
+      \"areaHectares\": 50.0
+    }")
+
+  PLOT_ID=$(echo "$PLOT_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null) || {
+    err "Create plot failed. Response: $PLOT_RESP"
+    return 1
+  }
+  log "Plot created: $PLOT_ID"
+
+  # ----------------------------------------------------------
+  # Step 5: Create Sensor (via Farm → RabbitMQ → SensorIngest)
+  # ----------------------------------------------------------
+  info "5/6 - Creating sensor (Farm publishes event → Sensor Ingest consumes)..."
+  SENSOR_RESP=$(curl -sf -X POST "$FARM_URL/api/sensors" \
+    -H "Content-Type: application/json" \
+    -H "$AUTH" \
+    -d "{
+      \"plotId\": \"$PLOT_ID\",
+      \"type\": \"Temperature\",
+      \"label\": \"Sensor Norte 1\"
+    }")
+
+  SENSOR_ID=$(echo "$SENSOR_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null) || {
+    err "Create sensor failed. Response: $SENSOR_RESP"
+    return 1
+  }
+  log "Sensor created in Farm: $SENSOR_ID"
+
+  # Wait a moment for the integration event to propagate via RabbitMQ
+  info "Waiting 3s for SensorRegisteredIntegrationEvent to propagate..."
+  sleep 3
+
+  # ----------------------------------------------------------
+  # Step 6: Send sensor reading (to Sensor Ingest)
+  # ----------------------------------------------------------
+  info "6/6 - Sending sensor reading to Sensor Ingest..."
+  READING_RESP=$(curl -sf -X POST "$SENSOR_URL/api/readings" \
+    -H "Content-Type: application/json" \
+    -H "$AUTH" \
+    -d "{
+      \"sensorId\": \"$SENSOR_ID\",
+      \"plotId\": \"$PLOT_ID\",
+      \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
+      \"temperature\": 28.5,
+      \"humidity\": 65.0,
+      \"soilMoisture\": 42.0,
+      \"rainfall\": null,
+      \"batteryLevel\": 85.0
+    }")
+
+  if echo "$READING_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('readingId',''))" 2>/dev/null | grep -q .; then
+    log "Reading accepted!"
+  else
+    warn "Reading response: $READING_RESP"
+    warn "If you see 'not registered' error, the integration event may not have propagated yet."
+    warn "Try sending the reading again manually."
+  fi
+
+  echo ""
+
+  # ----------------------------------------------------------
+  # Verify: List sensors from Sensor Ingest
+  # ----------------------------------------------------------
+  info "=== Verification ==="
+  info "Sensors in Sensor Ingest:"
+  curl -sf "$SENSOR_URL/api/sensors" -H "$AUTH" | python3 -m json.tool 2>/dev/null || warn "Could not list sensors"
+
+  echo ""
+  info "Dashboard stats:"
+  curl -sf "$SENSOR_URL/api/dashboard/stats" -H "$AUTH" | python3 -m json.tool 2>/dev/null || warn "Could not get stats"
+
+  echo ""
+}
+
+print_urls() {
+  echo ""
+  echo -e "${CYAN}========================================${NC}"
+  echo -e "${CYAN}  TC Agro Solutions - Access URLs${NC}"
+  echo -e "${CYAN}========================================${NC}"
+  echo ""
+  echo -e "  Frontend:        ${GREEN}$FRONTEND_URL${NC}"
+  echo -e "  Identity API:    $IDENTITY_URL"
+  echo -e "  Farm API:        $FARM_URL"
+  echo -e "  Sensor Ingest:   $SENSOR_URL"
+  echo ""
+  echo -e "  RabbitMQ UI:     http://localhost:15672  (guest/guest)"
+  echo -e "  pgAdmin:         http://localhost:15432  (admin@admin.com/admin)"
+  echo -e "  Grafana:         http://localhost:3000   (admin/admin)"
+  echo ""
+  echo -e "  Test credentials: ${GREEN}producer@test.com / Test@123456${NC}"
+  echo ""
+  echo -e "${CYAN}========================================${NC}"
+}
+
+stop_stack() {
+  info "Stopping all services..."
+  docker compose down
+  log "All services stopped."
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+case "${1:-}" in
+  --seed)
+    seed_data
+    print_urls
+    ;;
+  --down)
+    stop_stack
+    ;;
+  --urls)
+    print_urls
+    ;;
+  *)
+    build_and_start
+    seed_data
+    print_urls
+
+    # Try to open browser
+    if command -v open &> /dev/null; then
+      info "Opening frontend in browser..."
+      open "$FRONTEND_URL"
+    elif command -v xdg-open &> /dev/null; then
+      xdg-open "$FRONTEND_URL"
+    fi
+    ;;
+esac

--- a/poc/frontend/js/utils.js
+++ b/poc/frontend/js/utils.js
@@ -97,10 +97,37 @@ function detectFarmApiBaseUrl() {
   return 'http://localhost:5002';
 }
 
+/**
+ * Detect Sensor Ingest API base URL based on context:
+ * 1. Manual override: VITE_SENSOR_INGEST_API_BASE_URL env var
+ * 2. Cluster context: BASE_URL === '/agro/' -> Sensor Ingest at '/sensor-ingest'
+ * 3. Dev mode: localhost:3000 -> Sensor Ingest at 'http://localhost:5003'
+ * 4. Docker Compose or other: default to 'http://localhost:5003'
+ */
+function detectSensorIngestApiBaseUrl() {
+  if (import.meta.env.VITE_SENSOR_INGEST_API_BASE_URL) {
+    return import.meta.env.VITE_SENSOR_INGEST_API_BASE_URL;
+  }
+
+  const base = import.meta.env.BASE_URL || '/';
+  const currentHost = window.location.host;
+
+  if (base === '/agro/') {
+    return '/sensor-ingest';
+  }
+
+  if (currentHost.includes('localhost:3000') || currentHost.includes('127.0.0.1:3000')) {
+    return 'http://localhost:5003';
+  }
+
+  return 'http://localhost:5003';
+}
+
 export const APP_CONFIG = {
   apiBaseUrl: detectApiBaseUrl(),
   identityApiBaseUrl: detectIdentityApiBaseUrl(),
   farmApiBaseUrl: detectFarmApiBaseUrl(),
+  sensorIngestApiBaseUrl: detectSensorIngestApiBaseUrl(),
   tokenKey: 'agro_token',
   userKey: 'agro_user',
   signalREnabled: import.meta.env.VITE_SIGNALR_ENABLED === 'true',


### PR DESCRIPTION
Add a k6 script (k6-sensor-feed.js) to simulate continuous IoT sensor readings (single or batch modes) with custom metrics and auth; supports env overrides and configurable VUs/intervals for load testing. Add test-stack.sh to build, start, wait-for services, seed test data (register user, create property/plot/sensor, send a reading) and print access URLs. Update frontend API (poc/frontend/js/api.js) and utils (poc/frontend/js/utils.js) to integrate with the Sensor Ingest service: add sensorIngestApi client, replace several mock endpoints with real API calls (dashboard, latest/historical readings, sensors, alerts, plots/properties CRUD), detect sensor ingest base URL, and point SignalR hub to the sensor ingest hub.